### PR TITLE
added role, and avatar configs

### DIFF
--- a/config-communicate.json
+++ b/config-communicate.json
@@ -13,7 +13,7 @@
     "disable_login_language_selector": true,
     "disable_3pid_login": false,
     "brand": "Lingo",
-    "checkForUpdates":false,    
+    "checkForUpdates":false,
     "branding": {
         "authFooterLinks": [
             {
@@ -50,6 +50,7 @@
     },
     "show_first_last_char_initials_on_avatar": true,
     "sort_directory_view_alphabetically": true,
+    "use_custom_text_label_on_left_menu": "Use the + to make a new room or search roles, people or services in directory",
     "directory": {
         "api": {
             "base_path": "http://localhost:12121/pegacorn/operations/directory/r1/",
@@ -63,9 +64,7 @@
               "role_suffix": "/PractitionerRoleFavourites"
             }
         },
-        "showExplorePublicRoomTile": false,
         "show_favorite_icon_in_directory_search": true,
-        "explorePublicRoomServerSelectionDropdown": false,
         "numberOfRecordsToShowInSearch": 20,
         "role": {
             "name": "Search Roles",
@@ -99,6 +98,8 @@
         "Volunteer": "#777567"
     },
     "roomDirectory": {
+        "showExplorePublicRoomTile": false,
+        "explorePublicRoomServerSelectionDropdown": false,
         "servers": [
             "matrix.org"
         ]
@@ -123,7 +124,7 @@
     "tabbedView":{
         "showSecondaryLogo": true,
         "secondaryLogoUrl": "themes/element/img/logos/element-logo-secondary.png",
-        "secondaryLogoAltText": "Org Logo"       
+        "secondaryLogoAltText": "Org Logo"
     },
     "authenticatedHomeScreen":{
         "showWelcomeToElementText": false,

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -63,13 +63,13 @@
     "directory": {
         "api": {
             "base_path": "http://localhost:12121/pegacorn/operations/directory/r1/",
-            "search_all_roles": "PractitionerRole",
+            "prefix": "Practitioner/",
+            "search_all_roles": "PractitionerRole/",
             "search_role_by_displayName": "practitionerRole/search?displayName=",
             "search_person_by_role": "Practitioner/donald.duck%40acme%2Eorg/PractitionerRoles",
             "matrix_rooms": "MatrixRoom",
             "practitioner_role-group": "Group",
             "favourites": {
-              "prefix": "Practitioner/",
               "role_suffix": "/PractitionerRoleFavourites"
             }
         },

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -97,19 +97,17 @@
             "feature_description": "Using a role directory you can search practitioner by a service name..."
         }
     },
-    "avatarColors": [
-        {
-            "Allied Health": "#AA4298",
-            "Executive": "#002677",
-            "General": "#C64C0B",
-            "Health Professional": "#7A5DCB",
-            "Medical Officer": "#00828C",
-            "Nursing and Midwifery": "#472D8C",
-            "Scientist": "#8B8013",
-            "Student": "#333740",
-            "Volunteer": "#777567"
-        }
-    ],
+    "avatarColors": {
+        "Allied Health": "#AA4298",
+        "Executive": "#002677",
+        "General": "#C64C0B",
+        "Health Professional": "#7A5DCB",
+        "Medical Officer": "#00828C",
+        "Nursing and Midwifery": "#472D8C",
+        "Scientist": "#8B8013",
+        "Student": "#333740",
+        "Volunteer": "#777567"
+    },
     "roomDirectory": {
         "servers": [
             "matrix.org"

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -81,20 +81,20 @@
             "name": "Search Roles",
             "showRoleDirectory": true,
             "placeholder": "Enter a role keyword(example: shortName) to search",
-            "feature_description": "Using a role directory you can search practitioner by short name as keyword. A short name can be also part of identification id for a role search.",
+            "feature_description": "Using a role directory you can search a role and start discussion. Search keyword must be a display name which is also part of role identification.",
             "showAdvancedRoleSearchDropdown": true
         },
         "people": {
             "name": "Search People",
             "showPeopleDirectory": false,
             "placeholder": "Enter a person's name...",
-            "feature_description": "Using a people directory you can search a practitioner by a a person's name."
+            "feature_description": "Using a people directory you can search a practitioner and start discussion. Search keyword must be a display name, which is also part of your identification."
         },
         "service": {
             "name": "Search Service",
             "showServiceDirectory": false,
             "placeholder": "Enter a service name...",
-            "feature_description": "Using a role directory you can search practitioner by a service name..."
+            "feature_description": "Using a service directory you can search a service and start discussion. Search keyword must be an organization display name."
         }
     },
     "avatarColors": {

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -57,10 +57,15 @@
             "prefix": "Practitioner/",
             "search_all_roles": "PractitionerRole/",
             "search_role_by_displayName": "practitionerRole/search?displayName=",
+            "organization_search_prefix": "Organization/",
+            "search_service_by_displayName": "Organization/search?displayName=",
+            "search_people_by_displayName": "Practitioner/search?displayName=",
             "matrix_rooms": "MatrixRoom",
             "practitioner_role-group": "Group",
             "favourites": {
-              "role_suffix": "/PractitionerRoleFavourites"
+              "role_suffix": "/PractitionerRoleFavourites",
+              "service_suffix": "/ServiceFavourites",
+              "people_suffix": "/PractitionerFavourites"
             }
         },
         "show_favorite_icon_in_directory_search": true,
@@ -97,7 +102,7 @@
         "Volunteer": "#777567"
     },
     "roomDirectory": {
-        "showExplorePublicRoomTile": false,
+        "showExplorePublicRooms": false,
         "explorePublicRoomServerSelectionDropdown": false,
         "servers": [
             "matrix.org"

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -57,7 +57,6 @@
             "prefix": "Practitioner/",
             "search_all_roles": "PractitionerRole/",
             "search_role_by_displayName": "practitionerRole/search?displayName=",
-            "search_person_by_role": "Practitioner/donald.duck%40acme%2Eorg/PractitionerRoles",
             "matrix_rooms": "MatrixRoom",
             "practitioner_role-group": "Group",
             "favourites": {

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -58,6 +58,58 @@
             "padding": "0 20px"
         }
     },
+    "show_first_last_char_initials_on_avatar": true,
+    "sort_directory_view_alphabetically": true,
+    "directory": {
+        "api": {
+            "base_path": "http://localhost:12121/pegacorn/operations/directory/r1/",
+            "search_all_roles": "PractitionerRole",
+            "search_role_by_displayName": "practitionerRole/search?displayName=",
+            "search_person_by_role": "Practitioner/donald.duck%40acme%2Eorg/PractitionerRoles",
+            "matrix_rooms": "MatrixRoom",
+            "practitioner_role-group": "Group",
+            "favourites": {
+              "prefix": "Practitioner/",
+              "role_suffix": "/PractitionerRoleFavourites"
+            }
+        },
+        "showExplorePublicRoomTile": false,
+        "show_favorite_icon_in_directory_search": true,
+        "explorePublicRoomServerSelectionDropdown": false,
+        "numberOfRecordsToShowInSearch": 20,
+        "role": {
+            "name": "Search Roles",
+            "showRoleDirectory": true,
+            "placeholder": "Enter a role keyword(example: shortName) to search",
+            "feature_description": "Using a role directory you can search practitioner by short name as keyword. A short name can be also part of identification id for a role search.",
+            "showAdvancedRoleSearchDropdown": true
+        },
+        "people": {
+            "name": "Search People",
+            "showPeopleDirectory": false,
+            "placeholder": "Enter a person's name...",
+            "feature_description": "Using a people directory you can search a practitioner by a a person's name."
+        },
+        "service": {
+            "name": "Search Service",
+            "showServiceDirectory": false,
+            "placeholder": "Enter a service name...",
+            "feature_description": "Using a role directory you can search practitioner by a service name..."
+        }
+    },
+    "avatarColors": [
+        {
+            "Allied Health": "#AA4298",
+            "Executive": "#002677",
+            "General": "#C64C0B",
+            "Health Professional": "#7A5DCB",
+            "Medical Officer": "#00828C",
+            "Nursing and Midwifery": "#472D8C",
+            "Scientist": "#8B8013",
+            "Student": "#333740",
+            "Volunteer": "#777567"
+        }
+    ],
     "roomDirectory": {
         "servers": [
             "matrix.org"
@@ -113,6 +165,7 @@
             ".m.rule.suppress_notices",
             ".m.rule.tombstone"
         ],
+        "UIFeature.identityServer": false,
         "MessageComposerInput.ctrlEnterToSend": true,
         "TextualBody.disableBigEmoji": true,
         "hideAvatarChanges": true,
@@ -155,13 +208,13 @@
         "UIFeature.registration": false,
         "custom_themes": [
             {
-                "name": "Pegacorn communicate - Light theme custom colors",
+                "name": "Lingo(light)",
                 "is_dark": false,
                 "fonts": {
                     "faces": [
                         {
                             "font-family": "Inter",
-                        	"src": [{"url": "/fonts/Inter-Regular.woff", "format": "ttf"}]
+                        	"src": [{"url": "/fonts/OpenSans-Regular", "format": "ttf"}]
                         }
                     ],
                     "general": "Inter, sans",

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -50,7 +50,7 @@
     },
     "show_first_last_char_initials_on_avatar": true,
     "sort_directory_view_alphabetically": true,
-    "use_custom_text_label_on_left_menu": "Use the + to make a new room or search roles, people or services in directory",
+    "left_hand_nav_help_text": "Use the + to contact or search for roles, people or services",
     "directory": {
         "api": {
             "base_path": "http://localhost:12121/pegacorn/operations/directory/r1/",
@@ -103,8 +103,8 @@
     },
     "roomDirectory": {
         "showExplorePublicRooms": false,
-        "explorePublicRoomServerSelectionDropdown": false,
-        "servers": [
+        "showExplorePublicRoomServerSelectionDropdown": false,
+        "DISABLED_servers": [
             "matrix.org"
         ]
     },
@@ -209,7 +209,7 @@
         "UIFeature.registration": false,
         "custom_themes": [
             {
-                "name": "Lingo(light)",
+                "name": "Communicate (light)",
                 "is_dark": false,
                 "fonts": {
                     "faces": [

--- a/config-communicate.json
+++ b/config-communicate.json
@@ -74,7 +74,7 @@
             "name": "Search Roles",
             "showRoleDirectory": true,
             "placeholder": "Enter a role keyword(example: shortName) to search",
-            "feature_description": "Using a role directory you can search a role and start discussion. Search keyword must be a display name which is also part of role identification.",
+            "feature_description": "Using a role directory you can search a role and start discussion. Search keyword must be a display name which is also part of role identification. You can also select multiple roles and start discussion separately with each role. Group chat is not supported at the moment with roles.",
             "showAdvancedRoleSearchDropdown": true
         },
         "people": {
@@ -84,7 +84,7 @@
             "feature_description": "Using a people directory you can search a practitioner and start discussion. Search keyword must be a display name, which is also part of your identification."
         },
         "service": {
-            "name": "Search Service",
+            "name": "Search Services",
             "showServiceDirectory": false,
             "placeholder": "Enter a service name...",
             "feature_description": "Using a service directory you can search a service and start discussion. Search keyword must be an organization display name."

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             /bin/cp -f /app/config-with-placeholders.json /app/config.json;
             sed -i \"s/<MatrixServerName>/{{ .Values.matrixServerName }}/\" /app/config.json;
             sed -i \"s/<HomeServerHostNameAndPort>/{{ .Values.homeServerHostNameAndPort }}/\" /app/config.json;
+            sed -i \"s+<DirectoryServiceProtocolAndHostNameAndPort>+{{ .Values.directoryServiceProtocolAndHostNameAndPort | default (printf "https://%s" .Values.homeServerHostNameAndPort) }}+\" /app/config.json;
             echo START of /app/config.json file content;
             echo ' ';
             cat /app/config.json;


### PR DESCRIPTION
This pull request brings changes for role directory and partially touches on services and people directory. This will automatically leverage work towards service directory and  people directory at a portion.

194064:  Web: As an Authenticated Practitioner, I should be able to Search the Role Directory, so that I can locate a Role and view their details.
224274:  As an authenticated Practitioner I would like to see my first and last name initials on avatar.
224329:  As an Authenticated Practitioner, all avatars on web display Lingo colors by role category so that I am shown accessibility friendly colors.
