### PR TITLE
222611-Submit-Chat-Message-on-Enter-Button: change the MessageCompose…

### DIFF
--- a/config-communicate.json
+++ b/config-communicate.json
@@ -111,7 +111,7 @@
             ".m.rule.suppress_notices",
             ".m.rule.tombstone"
         ],
-        "MessageComposerInput.ctrlEnterToSend": true,
+        "MessageComposerInput.ctrlEnterToSend": false,
         "TextualBody.disableBigEmoji": true,
         "hideAvatarChanges": true,
         "hideDisplaynameChanges": true,


### PR DESCRIPTION
…rInput.ctrlEnterToSend config value from true to false, to allow Enter to do the Submit.  Shift+Enter already did a new line.