### PR TITLE
Feature/enable group discussion

### DIFF
--- a/config-communicate.json
+++ b/config-communicate.json
@@ -42,6 +42,9 @@
     "default_theme": "light",
     "feature_custom_themes": true,
     "auto_redirect_from_welcome_screen_to_login": true,
+    "presence_dashboard": {
+        "homepageUrl": "https://lingo-server.site-a/role-dashboard/"
+        },
     "footer": {
         "logo": {
             "altText": "Org Logo",
@@ -69,6 +72,8 @@
               "people_suffix": "/PractitionerFavourites"
             }
         },
+        "showDiscussionInDirectory": true,
+        "showGroupDiscussionInDirectory": true,
         "show_favorite_icon_in_directory_search": true,
         "showUserPresenceIndicator": true,
         "showDirectoryContactViewOnDirectorySearch": true,


### PR DESCRIPTION
225902 Web: As an Authenticated Practitioner, when a have authenticated into Lingo Web and been re-directed to the Landing Page, I want to be presented with the same User Functions as Android & iOS  plus the Presence Dashboard

Following have implemented:
- Create one to one discussion between two people.
- Create one to many conversation ( chat room ) and select title and description at the time of creating a room.
-  Do directory search by changing the directory from same modal screen without closing it by selecting options through multi select dropdown.
- Implemented dialog prompt that stops user to create group dialog if selected user is not more than one.